### PR TITLE
Add Dagger2

### DIFF
--- a/BrusovCodeTest/app/build.gradle
+++ b/BrusovCodeTest/app/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 27
@@ -27,6 +26,14 @@ dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+
+    // Dagger
+    implementation "com.google.dagger:dagger:$rootProject.daggerVersion"
+    implementation "com.google.dagger:dagger-android:$rootProject.daggerVersion"
+    implementation "com.google.dagger:dagger-android-support:$rootProject.daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$rootProject.daggerVersion"
+    kapt "com.google.dagger:dagger-android-processor:$rootProject.daggerVersion"
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/App.kt
+++ b/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/App.kt
@@ -1,0 +1,21 @@
+package com.eugenebrusov.brusovcodetest
+
+import android.app.Activity
+import android.app.Application
+import com.eugenebrusov.brusovcodetest.di.AppInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasActivityInjector
+import javax.inject.Inject
+
+class App : Application(), HasActivityInjector {
+    @Inject
+    lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Activity>
+
+    override fun onCreate() {
+        super.onCreate()
+
+        AppInjector.init(this)
+    }
+
+    override fun activityInjector() = dispatchingAndroidInjector
+}

--- a/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/AppComponent.kt
+++ b/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/AppComponent.kt
@@ -1,0 +1,27 @@
+package com.eugenebrusov.brusovcodetest.di
+
+import android.app.Application
+import com.eugenebrusov.brusovcodetest.App
+import com.eugenebrusov.brusovcodetest.di.modules.ActivityModule
+import dagger.BindsInstance
+import dagger.Component
+import dagger.android.AndroidInjectionModule
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+        modules = [
+            AndroidInjectionModule::class,
+            ActivityModule::class]
+)
+interface AppComponent {
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        fun build(): AppComponent
+    }
+
+    fun inject(app: App)
+}

--- a/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/AppInjector.kt
+++ b/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/AppInjector.kt
@@ -1,0 +1,48 @@
+package com.eugenebrusov.brusovcodetest.di
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentActivity
+import android.support.v4.app.FragmentManager
+import com.eugenebrusov.brusovcodetest.App
+import dagger.android.AndroidInjection
+import dagger.android.support.AndroidSupportInjection
+import dagger.android.support.HasSupportFragmentInjector
+
+object AppInjector {
+    fun init(app: App) {
+        DaggerAppComponent.builder().application(app)
+                .build().inject(app)
+        app.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                AndroidInjection.inject(activity)
+            }
+
+            override fun onActivityStarted(activity: Activity) {
+
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+
+            }
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle?) {
+
+            }
+
+            override fun onActivityDestroyed(activity: Activity) {
+
+            }
+        })
+    }
+}

--- a/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/modules/ActivityModule.kt
+++ b/BrusovCodeTest/app/src/main/java/com/eugenebrusov/brusovcodetest/di/modules/ActivityModule.kt
@@ -1,0 +1,11 @@
+package com.eugenebrusov.brusovcodetest.di.modules
+
+import com.eugenebrusov.brusovcodetest.RepoListActivity
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+abstract class ActivityModule {
+    @ContributesAndroidInjector()
+    abstract fun contributeMainActivity(): RepoListActivity
+}

--- a/BrusovCodeTest/build.gradle
+++ b/BrusovCodeTest/build.gradle
@@ -25,3 +25,7 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext {
+    daggerVersion = '2.15'
+}


### PR DESCRIPTION
As it's mentioned in https://developer.android.com/jetpack/docs/guide Google's Dagger 2 is the recommended library to manage dependencies. Since it allows to scale code and provides clear patterns for managing dependencies without duplicating code or adding complexity.